### PR TITLE
AllData method throw InvalidOperationException if datamodel contains a Owned Entity Type

### DIFF
--- a/src/Verify.EntityFramework/VerifyEntityFramework.cs
+++ b/src/Verify.EntityFramework/VerifyEntityFramework.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
 
@@ -11,7 +12,7 @@ namespace VerifyTests
         {
             Guard.AgainstNull(data, nameof(data));
 
-            foreach (var entityType in data.EntityTypes())
+            foreach (var entityType in data.EntityTypes().Where(p => !p.IsOwned()))
             {
                 var clrType = entityType.ClrType;
                 var set = data.Set(clrType);


### PR DESCRIPTION
Owned EntityTypes cannot be instantiated as DbSets so they need to filtered out of this call.  See https://docs.microsoft.com/en-us/ef/core/modeling/owned-entities#by-design-restrictions