### PR TITLE
Use Testcontainers to run tests on Linux and macOS

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="Polyfill" Version="10.6.0" />
     <PackageVersion Include="ProjectDefaults" Version="1.0.174" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.9.1" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.11.0" />
     <PackageVersion Include="Verify" Version="31.16.3" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageVersion Include="Verify.NUnit" Version="31.16.3" />

--- a/src/Verify.EntityFramework.Tests/DbUpdateExceptionTests.cs
+++ b/src/Verify.EntityFramework.Tests/DbUpdateExceptionTests.cs
@@ -4,7 +4,7 @@ public class DbUpdateExceptionTests
     [Test]
     public async Task Run()
     {
-        var instance = new SqlInstance<TestDbContext>(builder => new(builder.Options));
+        var instance = new SqlInstanceProvider<TestDbContext>(builder => new(builder.Options));
         var id = Guid.NewGuid();
         var entity = new TestEntity
         {

--- a/src/Verify.EntityFramework.Tests/GlobalUsings.cs
+++ b/src/Verify.EntityFramework.Tests/GlobalUsings.cs
@@ -1,11 +1,14 @@
-﻿global using System.ComponentModel.DataAnnotations.Schema;
+global using System.ComponentModel.DataAnnotations.Schema;
 global using System.Net.Http.Json;
 global using Argon;
+global using DotNet.Testcontainers.Containers;
 global using Microsoft.AspNetCore.Builder;
 global using Microsoft.AspNetCore.Hosting;
 global using Microsoft.AspNetCore.Mvc.Testing;
 global using Microsoft.AspNetCore.TestHost;
+global using Microsoft.Data.SqlClient;
 global using Microsoft.Data.Sqlite;
 global using Microsoft.EntityFrameworkCore;
 global using Microsoft.Extensions.DependencyInjection;
 global using Microsoft.Extensions.Hosting;
+global using Testcontainers.MsSql;

--- a/src/Verify.EntityFramework.Tests/Snippets/ContainerSqlDatabase.cs
+++ b/src/Verify.EntityFramework.Tests/Snippets/ContainerSqlDatabase.cs
@@ -1,0 +1,13 @@
+public sealed class ContainerSqlDatabase<TDbContext>(Func<TDbContext> dbContext) : ISqlDatabase<TDbContext>
+    where TDbContext : DbContext
+{
+    public string ConnectionString => Context.Database.GetConnectionString()!;
+
+    public TDbContext Context { get; } = dbContext();
+
+    public TDbContext NewDbContext() => dbContext();
+
+    public Task AddData(params object[] entities) => Context.AddData(entities);
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+}

--- a/src/Verify.EntityFramework.Tests/Snippets/DbContextBuilder.cs
+++ b/src/Verify.EntityFramework.Tests/Snippets/DbContextBuilder.cs
@@ -1,4 +1,4 @@
-﻿// LocalDb is used to make the sample simpler.
+// LocalDb is used to make the sample simpler.
 // Replace with a real DbContext
 
 public static class DbContextBuilder
@@ -14,7 +14,7 @@ public static class DbContextBuilder
             });
         descriptiveAliasSqlInstance = new(
             buildTemplate: CreateDb,
-            storage: Storage.FromSuffix<SampleDbContext>("DescriptiveTableAliases"),
+            storageSuffix: "DescriptiveTableAliases",
             constructInstance: builder =>
             {
                 builder.EnableRecording();
@@ -23,7 +23,7 @@ public static class DbContextBuilder
             });
         descriptiveParameterNamesSqlInstance = new(
             buildTemplate: CreateDb,
-            storage: Storage.FromSuffix<SampleDbContext>("DescriptiveParameterNames"),
+            storageSuffix: "DescriptiveParameterNames",
             constructInstance: builder =>
             {
                 builder.EnableRecording();
@@ -32,9 +32,9 @@ public static class DbContextBuilder
             });
     }
 
-    static SqlInstance<SampleDbContext> sqlInstance;
-    static SqlInstance<SampleDbContext> descriptiveAliasSqlInstance;
-    static SqlInstance<SampleDbContext> descriptiveParameterNamesSqlInstance;
+    static SqlInstanceProvider<SampleDbContext> sqlInstance;
+    static SqlInstanceProvider<SampleDbContext> descriptiveAliasSqlInstance;
+    static SqlInstanceProvider<SampleDbContext> descriptiveParameterNamesSqlInstance;
 
     static async Task CreateDb(SampleDbContext data)
     {
@@ -85,12 +85,12 @@ public static class DbContextBuilder
         await data.SaveChangesAsync();
     }
 
-    public static Task<SqlDatabase<SampleDbContext>> GetDatabase([CallerMemberName] string suffix = "")
+    public static Task<ISqlDatabase<SampleDbContext>> GetDatabase([CallerMemberName] string suffix = "")
         => sqlInstance.Build(suffix);
 
-    public static Task<SqlDatabase<SampleDbContext>> GetDescriptiveAliasDatabase([CallerMemberName] string suffix = "")
+    public static Task<ISqlDatabase<SampleDbContext>> GetDescriptiveAliasDatabase([CallerMemberName] string suffix = "")
         => descriptiveAliasSqlInstance.Build(suffix);
 
-    public static Task<SqlDatabase<SampleDbContext>> GetDescriptiveParameterNamesDatabase([CallerMemberName] string suffix = "")
+    public static Task<ISqlDatabase<SampleDbContext>> GetDescriptiveParameterNamesDatabase([CallerMemberName] string suffix = "")
         => descriptiveParameterNamesSqlInstance.Build(suffix);
 }

--- a/src/Verify.EntityFramework.Tests/Snippets/ISqlDatabase.cs
+++ b/src/Verify.EntityFramework.Tests/Snippets/ISqlDatabase.cs
@@ -1,0 +1,11 @@
+public interface ISqlDatabase<out TDbContext> : IAsyncDisposable
+    where TDbContext : DbContext
+{
+    string ConnectionString { get; }
+
+    TDbContext Context { get; }
+
+    TDbContext NewDbContext();
+
+    Task AddData(params object[] entities);
+}

--- a/src/Verify.EntityFramework.Tests/Snippets/LocalDbSqlDatabase.cs
+++ b/src/Verify.EntityFramework.Tests/Snippets/LocalDbSqlDatabase.cs
@@ -1,0 +1,13 @@
+public sealed class LocalDbSqlDatabase<TDbContext>(SqlDatabase<TDbContext> sqlDatabase) : ISqlDatabase<TDbContext>
+    where TDbContext : DbContext
+{
+    public string ConnectionString { get; } = sqlDatabase.ConnectionString;
+
+    public TDbContext Context { get; } = sqlDatabase.Context;
+
+    public TDbContext NewDbContext() => sqlDatabase.NewDbContext();
+
+    public Task AddData(params object[] entities) => sqlDatabase.AddData(entities);
+
+    public ValueTask DisposeAsync() => sqlDatabase.DisposeAsync();
+}

--- a/src/Verify.EntityFramework.Tests/Snippets/SqlInstanceProvider.cs
+++ b/src/Verify.EntityFramework.Tests/Snippets/SqlInstanceProvider.cs
@@ -1,0 +1,107 @@
+public class SqlInstanceProvider<TDbContext> : IAsyncDisposable
+    where TDbContext : DbContext
+{
+    readonly TemplateFromContext<TDbContext>? buildTemplate;
+    readonly ConstructInstance<TDbContext> constructInstance;
+
+    SemaphoreSlim semaphore = new(1);
+    SqlInstance<TDbContext>? sqlInstance;
+    MsSqlContainer? sqlContainer;
+
+    public SqlInstanceProvider(ConstructInstance<TDbContext> constructInstance, TemplateFromContext<TDbContext>? buildTemplate = null, string? storageSuffix = null)
+    {
+        this.buildTemplate = buildTemplate;
+        this.constructInstance = constructInstance;
+        if (string.Equals(Environment.GetEnvironmentVariable("VERIFY_ENTITYFRAMEWORK_TESTS_SQLENGINE"), "Docker", StringComparison.OrdinalIgnoreCase) || !OperatingSystem.IsWindows())
+        {
+            var suffix = storageSuffix == null ? "" : $".{storageSuffix}";
+            sqlContainer = new MsSqlBuilder("mcr.microsoft.com/mssql/server:2025-latest")
+                .WithName($"Verify.EntityFramework.Tests{suffix}")
+                .WithReuse(true)
+                .Build();
+        }
+        else
+        {
+            sqlInstance = new(
+                buildTemplate: buildTemplate,
+                storage: storageSuffix == null ? null : Storage.FromSuffix<TDbContext>(storageSuffix),
+                constructInstance: constructInstance);
+        }
+    }
+
+    public async Task<ISqlDatabase<TDbContext>> Build(IEnumerable<object> data, [CallerFilePath] string testFile = "", string? databaseSuffix = null, [CallerMemberName] string memberName = "")
+    {
+        if (sqlInstance != null)
+        {
+            var sqlDatabase = await sqlInstance.Build(data, testFile, databaseSuffix, memberName);
+            return new LocalDbSqlDatabase<TDbContext>(sqlDatabase);
+        }
+
+        if (sqlContainer != null)
+        {
+            var testClass = Path.GetFileNameWithoutExtension(testFile);
+            var dbName = databaseSuffix == null ? $"{testClass}_{memberName}" : $"{testClass}_{memberName}_{databaseSuffix}";
+            var sqlDatabase = await Build(dbName);
+            await sqlDatabase.AddData(data);
+            return sqlDatabase;
+        }
+
+        throw new UnreachableException("Both sqlInstance and sqlContainer can't be null at the same time");
+    }
+
+    public async Task<ISqlDatabase<TDbContext>> Build([CallerMemberName] string dbName = "")
+    {
+        if (sqlInstance != null)
+        {
+            var sqlDatabase = await sqlInstance.Build(dbName);
+            return new LocalDbSqlDatabase<TDbContext>(sqlDatabase);
+        }
+
+        if (sqlContainer != null)
+        {
+            await semaphore.WaitAsync();
+            try
+            {
+                if (sqlContainer.State != TestcontainersStates.Running)
+                {
+                    await sqlContainer.StartAsync();
+                }
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+
+            var result = await sqlContainer.ExecScriptAsync($"DROP DATABASE IF EXISTS [{dbName}]");
+            if (result.ExitCode != 0)
+            {
+                throw new InvalidOperationException($"Failed to drop database '{dbName}' ({result.ExitCode})\n{result.Stdout}\n{result.Stderr}");
+            }
+
+            await using var dbContext = CreateDbContext(dbName);
+            await dbContext.Database.EnsureCreatedAsync();
+
+            if (buildTemplate != null)
+            {
+                await buildTemplate(dbContext);
+            }
+
+            return new ContainerSqlDatabase<TDbContext>(() => CreateDbContext(dbName));
+        }
+
+        throw new UnreachableException("Both sqlInstance and sqlContainer can't be null at the same time");
+    }
+
+    private TDbContext CreateDbContext(string dbName)
+    {
+        var connectionString = new SqlConnectionStringBuilder(sqlContainer!.GetConnectionString()) { InitialCatalog = dbName }.ConnectionString;
+        return constructInstance(new DbContextOptionsBuilder<TDbContext>().UseSqlServer(connectionString));
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        semaphore.Dispose();
+        sqlInstance?.Dispose();
+        return sqlContainer?.DisposeAsync() ?? ValueTask.CompletedTask;
+    }
+}

--- a/src/Verify.EntityFramework.Tests/Verify.EntityFramework.Tests.csproj
+++ b/src/Verify.EntityFramework.Tests/Verify.EntityFramework.Tests.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Testcontainers.MsSql" />
     <PackageReference Include="Verify.DiffPlex" />
     <PackageReference Include="MarkdownSnippets.MsBuild" PrivateAssets="all" />
     <PackageReference Include="Verify.NUnit" />


### PR DESCRIPTION
I wanted to add a new setting to disable SQL reformatting in Verify.EntityFramework but first I needed to run tests on macOS. Since LocalDb is Windows only, I used [Testconainers](https://github.com/testcontainers/testcontainers-dotnet/) to run the tests.