### PR TITLE
Scope EF converters to Verify settings

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -300,7 +300,7 @@ Recording is attached by `EnableRecording()`. Pass `recordCommands: false` to `I
 ```cs
 VerifyEntityFramework.Initialize(data, recordCommands: false);
 ```
-<sup><a href='/src/Verify.EntityFramework.RecordingDisabledTests/ModuleInitializer.cs#L10-L14' title='Snippet source file'>snippet source</a> | <a href='#snippet-DisableRecording' title='Start of snippet'>anchor</a></sup>
+<sup><a href='/src/Verify.EntityFramework.RecordingDisabledTests/ModuleInitializer.cs#L8-L12' title='Snippet source file'>snippet source</a> | <a href='#snippet-DisableRecording' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 Only recording is disabled. The converters, and the queryable to SQL file converter, are still registered.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <PropertyGroup>
     <NoWarn>CS1591;CS0649;CS8632;EF1001;NU1608;NU1109</NoWarn>
-    <Version>15.3.0</Version>
+    <Version>15.3.1</Version>
     <LangVersion>preview</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <PackageTags>EntityFramework, Verify</PackageTags>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -17,15 +17,15 @@
     <PackageVersion Include="Microsoft.SqlServer.TransactSql.ScriptDom" Version="180.37.3" />
     <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
-    <PackageVersion Include="Polyfill" Version="10.11.2" />
+    <PackageVersion Include="Polyfill" Version="11.0.1" />
     <PackageVersion Include="ProjectDefaults" Version="1.0.174" />
     <PackageVersion Include="System.Data.SqlClient" Version="4.9.1" />
-    <PackageVersion Include="Verify" Version="31.24.1" />
+    <PackageVersion Include="Verify" Version="31.24.2" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.3.1" />
-    <PackageVersion Include="Verify.NUnit" Version="31.24.1" />
+    <PackageVersion Include="Verify.NUnit" Version="31.24.2" />
     <PackageVersion Include="Verify.SqlServer" Version="12.2.0" />
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.5" />
-    <PackageVersion Include="Argon" Version="0.35.1" />
+    <PackageVersion Include="Argon" Version="0.35.2" />
     <PackageVersion Include="DiffEngine" Version="19.3.2" />
     <PackageVersion Include="EmptyFiles" Version="8.18.2" />
     <PackageVersion Include="SimpleInfoName" Version="3.2.0" />

--- a/src/Verify.EntityFramework.RecordingDisabledTests/ModuleInitializer.cs
+++ b/src/Verify.EntityFramework.RecordingDisabledTests/ModuleInitializer.cs
@@ -1,5 +1,3 @@
-using Microsoft.EntityFrameworkCore.Metadata;
-
 public static class ModuleInitializer
 {
     [ModuleInitializer]

--- a/src/Verify.EntityFramework/DescriptiveParameterNameGenerator.cs
+++ b/src/Verify.EntityFramework/DescriptiveParameterNameGenerator.cs
@@ -5,7 +5,7 @@ class DescriptiveParameterNameGenerator :
     Dictionary<string, (int count, string entityName)> names = new(StringComparer.OrdinalIgnoreCase);
 
     // All generated param names, for collision detection
-    HashSet<string> allGenerated = new(StringComparer.OrdinalIgnoreCase);
+    HashSet<string> allGenerated = [with(StringComparer.OrdinalIgnoreCase)];
 
     string? pendingColumnName;
     string? pendingEntityName;

--- a/src/Verify.EntityFramework/VerifyEntityFramework.cs
+++ b/src/Verify.EntityFramework/VerifyEntityFramework.cs
@@ -144,11 +144,15 @@ public static class VerifyEntityFramework
             (target, _) => QueryableConverter.IsQueryable(target));
         VerifierSettings.IgnoreMembersWithType(typeof(IDbContextFactory<>));
         VerifierSettings.IgnoreMembersWithType<DbContext>();
-        var converters = DefaultContractResolver.Converters;
-        converters.Add(new DbUpdateExceptionConverter());
-        converters.Add(new TrackerConverter());
-        converters.Add(new QueryableConverter());
-        converters.Add(new LogEntryConverter());
+
+        VerifierSettings.AddExtraSettings(settings =>
+        {
+            var converters = settings.Converters;
+            converters.Add(new DbUpdateExceptionConverter());
+            converters.Add(new TrackerConverter());
+            converters.Add(new QueryableConverter());
+            converters.Add(new LogEntryConverter());
+        });
     }
     static bool IsSqlServer(this IModel model)
     {


### PR DESCRIPTION
Switch converter registration from `DefaultContractResolver.Converters` to `VerifierSettings.AddExtraSettings(...)` so EF converters are added through Verify’s serializer settings pipeline. Also updates related package versions (Verify/Verify.NUnit, Argon, Polyfill), removes an unused using, tweaks a HashSet initialization style, and refreshes a README snippet line reference.